### PR TITLE
issue-9: Fix issue where burning zombies regen health.

### DIFF
--- a/Contents/mods/RandomZombiesDayAndNight/media/lua/server/rzf_zombiesManager.lua
+++ b/Contents/mods/RandomZombiesDayAndNight/media/lua/server/rzf_zombiesManager.lua
@@ -179,7 +179,12 @@ zombiesManager.updateZombie = function(zombie, distribution, speedType, cognitio
 
     -- update toughness
     if distribution.normal ~= 100 then
-      if not zombie:getAttackedBy() then
+      -- Only update health of zombies that are not on fire and not being attacked.
+      -- The getAttackedBy() check returns truthy if the last damage the zombie took was from a player...
+      -- however if the zombie is on fire, then any fire damage will cause the "AttackedBy" status to expire,
+      -- so we need to also check for burning, otherwise burning zombies will regen health.
+      -- See https://github.com/theCrius/project-zomboid-random-zombies-full/issues/9 for more info.
+      if not zombie:getAttackedBy() and not zombie:isOnFire() then
         zid = utilities.hash(zid)
         local slice3 = utilities.hashToSlice(zid)
         local health = 0.1 * ZombRand(4)


### PR DESCRIPTION
This PR is a fix for:
https://github.com/theCrius/project-zomboid-random-zombies-full/issues/9

The problem was that whenever a zed takes fire damage, this will cause `getAttackedBy()` to return nil... thus burning zeds were eligible to have their health updated, causing them to regen.  Issue was fixed by adding check for the "OnFire" status.

I'm definitely not attached to the added comments, so please modify them as you see fit.